### PR TITLE
Make next up section ignore on demand sessions + remove signal alias

### DIFF
--- a/src/commands/signal2022/index.js
+++ b/src/commands/signal2022/index.js
@@ -23,10 +23,6 @@ baseFlags.profile.description =
 class Signal2022Command extends TwilioClientCommand {
   static strict = false;
 
-  static aliases = ['signal'];
-
-  static examples = ['$ twilio signal'];
-
   static flags = {
     ...baseFlags,
     diagnostics: Flags.boolean({
@@ -131,7 +127,7 @@ class Signal2022Command extends TwilioClientCommand {
     shouldCleanScreen = !debug;
     await render(
       {
-        name: 'Operator',
+        name: '',
         accountSid: this.twilioClient.accountSid,
         twilioUsername: this.twilioClient.username,
         twilioPassword: this.twilioClient.password,

--- a/src/components/sidebar/NextUpSection.tsx
+++ b/src/components/sidebar/NextUpSection.tsx
@@ -77,7 +77,8 @@ export type NextUpProps = {
 
 export function NextUp({ sessions }: NextUpProps) {
   const { ref, shouldRender } = useBreakpointForElement({ minHeight: 7 });
-  const nextSessions = useNextSessions(sessions);
+  const cleanSessions = sessions.filter((session) => !!session.startTime);
+  const nextSessions = useNextSessions(cleanSessions);
 
   return (
     <Box ref={ref} flexDirection="column" padding={1} height={7}>


### PR DESCRIPTION
Ignore on demand sessions when calculating next up session + remove `signal` alias
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
